### PR TITLE
Create 2024-03-07 post-mortems

### DIFF
--- a/2024-03/2024-03-07-inefficient-mempool_item-selection.md
+++ b/2024-03/2024-03-07-inefficient-mempool_item-selection.md
@@ -1,0 +1,40 @@
+# Inefficient Mempool Item selection.
+
+## Issue Summary
+
+Blocks were not filled with transactions to capacity.
+
+Chia's consensus allows for 11 Billion in CLVM cost to be added to a block in transactions, where the CLVM cost for each transaction depends on their complexity, coins involved etc.
+When a farmer creates a block with transactions, it will select them from their mempool in order of `fee per cost`.
+
+The mempool item selection algorithm fills a new block by repeatedly selecting the highest-priority transaction from the mempool.
+When the next transaction would overfill the block, the node would consider the block finished and submit it to the network.
+
+This was inefficient in some cases. For example, if a block was less than half full, but the next transaction in the queue was large enough to overfill the block, the node would stop looking for more transactions. The resulting block would be filled to nowhere near capacity, even though it could have held many smaller transactions.
+
+
+The following situation occurred:
+- a transaction was in the mempool with CLVM cost that was close in size to the mempool selection algorithm maximum. 
+- the transaction's `fee per cost` was not high enough for the mempool selection algorithm to add it first, yet reasonably high to have it inspected soon after.
+
+As a result the mempool selection algorithm would select other items first, and detecting the "stuck" large item would exceed the maximum stop there.
+This resulted in blocks to contain only a few transactions and the "stuck" transaction to not be included and cause the same issue in the subsequent blocks.
+
+
+## Timeline (all times PST) 01/16/2024 - 02/28/2024. All times approximations
+
+01-16-2024 - Chia detected sub optimal transaction inclusion in blocks due to the "stuck" transaction.
+
+01-16-2024 - A Chia farmer of reasonable size was asked to include the "stuck" transaction in a block, and the farmer created such a block.
+
+01-25-2024 - A better selection algorithm was introduced to the codebase at https://github.com/Chia-Network/chia-blockchain/pull/17346
+
+02-28-2024 - Version 2.2.0 was released that included the fix.
+
+
+## Resolution and recovery
+
+The immediate resolution was to ensure the "stuck" transaction to be included into a block by a Chia farmer.
+A Chia farmer of reasonable size was asked to do this and farmed such a block.
+
+To prevent such a situation in the future, a new block-fill algorithm was created that attempts to strike a balance, filling blocks efficiently, while also being careful not to take too much time in selecting transactions.

--- a/2024-03/2024-03-07-mempool-not-updated-at-re_org.md
+++ b/2024-03/2024-03-07-mempool-not-updated-at-re_org.md
@@ -1,0 +1,27 @@
+# Mempool not updated at re-org.
+
+## Issue Summary
+
+Due to a bug in the Mempool code at the time of a re-org, if the latest block was a non transaction block, the mempool did not get updated until the next transaction block occurred.
+
+When a farmer would have an outdated Mempool and add conflicting items into their farmed block, a block without any transactions would be created instead.
+
+For more information on re-orgs and transaction blocks, visit:
+https://docs.chia.net/consensus-foliage/
+
+
+## Timeline (all times PST) 01/05/2024 - 02/28/2024. All times approximations
+
+01-05-2024 - A bug report was created that informed Chia of the issue at https://github.com/Chia-Network/chia-blockchain/issues/17186
+
+01-20-2024 - The codebase was updated with a fix at https://github.com/Chia-Network/chia-blockchain/pull/17370
+
+02-28-2024 - Version 2.2.0 was released that included the fix. 
+
+
+## Resolution and recovery
+
+A fix was introduced to have the mempool update immediately with a reorg via Blockchain.get_tx_peak(), which returns the most recent transaction block (which may be the peak, if that is a transaction block).
+
+For more information about the issue and resolution, visit:
+https://github.com/Chia-Network/chia-blockchain/pull/17370

--- a/2024-03/2024-03-07-unfinished_blocks-cache.md
+++ b/2024-03/2024-03-07-unfinished_blocks-cache.md
@@ -1,0 +1,35 @@
+# v2.2.0 unfinished_block cache retrieval issue.
+
+## Issue Summary
+
+If multiple farmers share plots and win, they will each produce a new unfinished_block with the same reward block hash.
+
+A new feature in 2.2.0 allows the network to propagate all unfinished_block variants (up to a limit) and pick the "best" one for infusion creating one full_block.
+
+When a node receives notification from a peer of a new_peak it requests the full_blocks it doesn’t have to sync to that peak height. The node will not ask for the block generator of the full_block when it already has the unfinished_block (with the needed block generator) in its cache as an optimization.
+
+The unfinished_block is pulled from the cache by its reward hash, and its cache insertion order determines which one is selected if there were multiple variants (with the same reward hash) of the unfinished_blocks in the cache. 
+
+This would result in the wrong item being pulled from the cache in some scenarios, causing the reconstructed full_block to include the wrong block generator. In that case validation of the full_block would fail and the peer that provided the full_block would get banned for 10 seconds.
+In addition the wrong execution results might get pulled from the cache as well due to the same issue, resulting in failed validation and peer bans.
+
+
+## Timeline (all times PST) 02/26/2024 - 03/06/2024. All times approximations
+
+02-26-2024 - `INVALID_TRANSACTIONS_FILTER_HASH` block validation was reported for the Release Candidate version in Chia’s Discord Server by beta testers.
+
+02-28-2024 - Version 2.2.0 was released to the public.
+
+02-29-2024 - The cache retrieval issue was confirmed and v2.2.0 was recalled.
+
+03-06-2024 - Version 2.2.1 was released that included the fix. 
+
+
+## Resolution and recovery
+
+A fix was introduced in v2.2.1 to make the unfinished_block selection from the cache deterministic by not only pulling the cached item by its reward block hash, but also taking the foliage hash into account when constructing the full_block.
+
+Version 2.2.0 with the cache retrieval issue was pulled, and version 2.2.1 that has the cache lookup fix was released as a replacement.
+
+For more information about the issue and resolution, visit:
+https://github.com/Chia-Network/chia-blockchain/pull/17622

--- a/2024-03/2024-03-07-unfinished_blocks-different-foliage.md
+++ b/2024-03/2024-03-07-unfinished_blocks-different-foliage.md
@@ -1,0 +1,32 @@
+# Unfinished_blocks with different Foliage.
+
+## Issue Summary
+
+When a farmer runs multiple (redundant) full node and farmer instances, harvesting the same plots, it's possible to produce multiple different unfinished blocks with the same proof-of-space. Full nodes may have slightly different views of the mempool, because of quirks in transaction  gossip. Therefore nodes may produce slightly different blocks. As an example, we consider a new transaction being propagated throughout the network that has reached one node but not the other when the block is created.
+
+Since the network sees these blocks as equally valid (because the reward block hash, i.e. proof-of-space) is the same, they will each propagate to nodes and which one is seen by which node is non deterministic because of the previously mentioned quirks in gossiping of transactions and blocks. This is a system designed to be unpredictable in an effort to provide defense against sybil type attacks. In a system with many competing timelords, different timelords are likely to infuse different versions of the unfinished blocks. Often timelords will not  be aware of the existence of the other variants of the chain, because it's never propagated to their part of the network.
+
+These blocks, once infused, will form competing chains, eventually resolved by one side of the network re-orging to the other chain.
+
+
+## Timeline (all times PST) 11/20/2023 - 02/28/2024. All times approximations
+
+11-20-2023 - A researcher submitted a bug report via bugcrowd (https://bugcrowd.com/chia-network-bb) detailing the issue.
+
+11-21-2023 - The ASIC timelords that sit geographically far apart were linked together by their full_nodes to ensure they see the same variant first, and only infuse that variant.
+
+01-26-2024 - A fix was introduced to the codebase at https://github.com/Chia-Network/chia-blockchain/pull/17247
+
+02-28-2024 - Version 2.2.0 was released that included the fix.
+
+
+## Resolution and recovery
+
+The immediate resolution was to ensure the fastest timelords on the Chia network, currently the ASIC timelords, were linked together by their fullnodes.
+This ensured that if multiple unfinished_block variants (each with different Foliage) were propagating on the network, the timelords would see the same variant first
+and ignore the other variants.
+
+The fix in the codebase allows for the multiple variants (up to 3) to reach the timelords, where the timelord will infuse only one (the one with the lowest foliage transaction block hash).
+
+For more information about the issue and resolution, visit:
+https://github.com/Chia-Network/chia-blockchain/pull/17247


### PR DESCRIPTION
2024-03-07 post-mortems for:

- Unfinished_blocks with different Foliage.
- Inefficient Mempool Item selection.
- Mempool not updated at re-org.
- v2.2.0 unfinished_block cache retrieval issue.